### PR TITLE
Temporarily disable speaker hall of fame

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ Turku &hearts; Frontend is the #1 community for frontend developers and designer
 
 We organize monthly meetups, hackathons, programming competitions and other gatherings to promote developer culture. Our doors are open for everyone: beginners, curious, hobbyists, professionals and beyond.
 
-Our meetups would not be possible without our [amazing speakers](/speakers).
+Our meetups would not be possible without our amazing speakers so thank you everyone who have shared your knowledge and experiences.
 
 Please note that everyone on our meetups is expected to act in accordance with the [Code of Conduct](/code-of-conduct) so we can build a community that is open and welcoming to everyone.
 


### PR DESCRIPTION
The speaker hall of fame is horribly out of date + needs a bit of rewrite anyway so this PR disables it.

Don't worry though, it'll come back soon-ish.